### PR TITLE
Clarify taxomony/vocabulary terminology

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -11,8 +11,8 @@
   <li>Create a Basic page and two Articles.</li>
   <li>Create a view for your Articles.</li>
   <li>Add a page to the main menu.</li>
-  <li>Create a new taxonomy and add terms.</li>
-  <li>Add the taxonomy to your Article content type.</li>
+  <li>Create a new taxonomy vocabulary and add terms.</li>
+  <li>Add the vocabulary as a new field on your Article content type.</li>
   <li>Add a Custom block and display in sidebar.</li>
 </ul>
 


### PR DESCRIPTION
The button in D8 says "Add vocabulary" not "Add taxonomy", so it seemed that this line here should say sometime similar.

Also clarify that it'll be a new field (rather than changing the existing 'tags' field on the Article content type).
