### PR TITLE
Make documenter text gender neutral

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -82,7 +82,7 @@
 
 <h2>Documenter</h2>
 
-<p>Eres <strong>Community Contributor</strong> con nociones de escribir en inglés, y estás preparado o preparada para compartir tus conocimientos sobre Drupal 8 con otros.</p>
+<p>Eres <strong>Community Contributor</strong> con nociones de escribir en inglés, y tienes la preparación para compartir tus conocimientos sobre Drupal 8 con otros.</p>
 
 <h3>Prepárate para el Sprint</h3>
 <ul>


### PR DESCRIPTION
I thought we fixed this issue on the spanish translation before, but seems that we missed it. Now, the text is gender neutral.
